### PR TITLE
feat: add branch attribute on provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ description: |-
 
 ### Optional
 
+- `branch` (String) Branchname to use for commits.
 - `http` (Attributes) (see [below for nested schema](#nestedatt--http))
 - `ignore_updates` (Boolean) If true, any updates to resources of type git_repository_file will be ignored.
 - `ssh` (Attributes) (see [below for nested schema](#nestedatt--ssh))

--- a/docs/resources/repository_file.md
+++ b/docs/resources/repository_file.md
@@ -45,10 +45,10 @@ resource "git_repository_file" "this" {
 
 Optional:
 
-- `create` (String)
-- `delete` (String)
-- `read` (String)
-- `update` (String)
+- `create` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
+- `delete` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Setting a timeout for a Delete operation is only applicable if changes are saved into state before the destroy operation occurs.
+- `read` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours). Read operations occur during any refresh or planning operation when refresh is enabled.
+- `update` (String) A string that can be [parsed as a duration](https://pkg.go.dev/time#ParseDuration) consisting of numbers and unit suffixes, such as "30s" or "2h45m". Valid time units are "s" (seconds), "m" (minutes), "h" (hours).
 
 ## Import
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,6 +25,7 @@ type Http struct {
 
 type GitProviderModel struct {
 	Url           types.String `tfsdk:"url"`
+	Branch        types.String `tfsdk:"branch"`
 	Ssh           *Ssh         `tfsdk:"ssh"`
 	Http          *Http        `tfsdk:"http"`
 	IgnoreUpdates types.Bool   `tfsdk:"ignore_updates"`
@@ -46,6 +47,10 @@ func (p *GitProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 		Attributes: map[string]schema.Attribute{
 			"url": schema.StringAttribute{
 				Required: true,
+			},
+			"branch": schema.StringAttribute{
+				Description: "Branchname to use for commits.",
+				Optional:    true,
 			},
 			"ssh": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -104,6 +109,7 @@ func (p *GitProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	}
 	resp.ResourceData = &ProviderResourceData{
 		url:            data.Url.ValueString(),
+		branch:         data.Branch.ValueString(),
 		ssh:            data.Ssh,
 		http:           data.Http,
 		ignore_updates: data.IgnoreUpdates.ValueBool(),

--- a/internal/provider/repository_file.go
+++ b/internal/provider/repository_file.go
@@ -107,8 +107,6 @@ func (r *RepositoryFileResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"branch": schema.StringAttribute{
 				Optional: true,
-				Computed: true,
-				Default:  stringdefault.StaticString("main"),
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -192,7 +190,12 @@ func (r *RepositoryFileResource) Create(ctx context.Context, req resource.Create
 			data.Path.ValueString(): strings.NewReader(data.Content.ValueString()),
 		}
 
-		client, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+		branch := r.prd.branch
+		if branch == "" {
+			branch = data.Branch.ValueString()
+		}
+
+		client, err := r.prd.GetGitClient(ctx, branch)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -279,7 +282,12 @@ func (r *RepositoryFileResource) Update(ctx context.Context, req resource.Update
 	}
 
 	err := retry.RetryContext(ctx, updateTimeout, func() *retry.RetryError {
-		client, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+		branch := r.prd.branch
+		if branch == "" {
+			branch = data.Branch.ValueString()
+		}
+
+		client, err := r.prd.GetGitClient(ctx, branch)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -337,7 +345,12 @@ func (r *RepositoryFileResource) Delete(ctx context.Context, req resource.Delete
 	}
 
 	err := retry.RetryContext(ctx, deleteTimeout, func() *retry.RetryError {
-		client, err := r.prd.GetGitClient(ctx, data.Branch.ValueString())
+		branch := r.prd.branch
+		if branch == "" {
+			branch = data.Branch.ValueString()
+		}
+
+		client, err := r.prd.GetGitClient(ctx, branch)
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}


### PR DESCRIPTION
This PR adds a `branch` attribute on the provider level. This can still be overridden by setting the same `branch` attribute on individual repository files. If no branch name has been defined on the provider or the  repository file, the default branch name `main` will be used, which is backward compatible with the previous version of the provider. In any case, **the branch must exist in the remote** before using the provider.