### PR TITLE
fix: branch attribute should not require replace

### DIFF
--- a/internal/provider/repository_file.go
+++ b/internal/provider/repository_file.go
@@ -107,9 +107,6 @@ func (r *RepositoryFileResource) Schema(ctx context.Context, req resource.Schema
 			},
 			"branch": schema.StringAttribute{
 				Optional: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"path": schema.StringAttribute{
 				Required: true,


### PR DESCRIPTION
This PR removes the need to replace `git_repository_file`(s) when the `branch` attribute changes. This is to address issues introduced by the previous release, which introduced the `branch` attribute on a provider level, which is the first step towards removing it from the `git_repository_file` resource. 

The way forward and how we intend this provider to be used is to create git files in a branch other than the default one, and then create PR:s to merge the files into the default branch. Furthermore, it doesn't make much sense to create the individual git files in different branches, so we intend to remove the branch attribute, together with the other attributes associated with the commit message and only have these on a provider level.