### PR TITLE
refactor:! move commit message attributes to provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,9 +22,20 @@ description: |-
 ### Optional
 
 - `branch` (String) Branchname to use for commits.
+- `commits` (Attributes) (see [below for nested schema](#nestedatt--commits))
 - `http` (Attributes) (see [below for nested schema](#nestedatt--http))
 - `ignore_updates` (Boolean) If true, any updates to resources of type git_repository_file will be ignored.
 - `ssh` (Attributes) (see [below for nested schema](#nestedatt--ssh))
+
+<a id="nestedatt--commits"></a>
+### Nested Schema for `commits`
+
+Optional:
+
+- `author_email` (String) Author email for commits.
+- `author_name` (String) Author name for commits.
+- `message` (String) Commit message.
+
 
 <a id="nestedatt--http"></a>
 ### Nested Schema for `http`

--- a/docs/resources/repository_file.md
+++ b/docs/resources/repository_file.md
@@ -29,9 +29,6 @@ resource "git_repository_file" "this" {
 
 ### Optional
 
-- `author_email` (String)
-- `author_name` (String)
-- `message` (String)
 - `override_on_create` (Boolean)
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type Ssh struct {
@@ -54,6 +55,17 @@ func (c *Commits) Msg() string {
 		return "Write file with Terraform Provider Git"
 	}
 	return c.Message.ValueString()
+}
+
+func newCommits(m *GitProviderModel) *Commits {
+	c := m.Commits
+	if c == nil {
+		c = &Commits{
+			AuthorName: basetypes.NewStringValue("Terraform Provider Git"),
+			Message:    basetypes.NewStringValue("Write file with Terraform Provider Git."),
+		}
+	}
+	return c
 }
 
 var _ provider.Provider = &GitProvider{}
@@ -154,7 +166,7 @@ func (p *GitProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		branch:         data.Branch.ValueString(),
 		ssh:            data.Ssh,
 		http:           data.Http,
-		commits:        data.Commits,
+		commits:        newCommits(&data),
 		ignore_updates: data.IgnoreUpdates.ValueBool(),
 	}
 }

--- a/internal/provider/provider_resource_data.go
+++ b/internal/provider/provider_resource_data.go
@@ -17,6 +17,7 @@ type ProviderResourceData struct {
 	branch         string
 	ssh            *Ssh
 	http           *Http
+	commits        *Commits
 	ignore_updates bool
 }
 
@@ -26,6 +27,10 @@ func (prd *ProviderResourceData) IgnoreUpdates(ctx context.Context) bool {
 
 func (prd *ProviderResourceData) Branch(ctx context.Context) string {
 	return prd.branch
+}
+
+func (prd *ProviderResourceData) Commits(ctx context.Context) *Commits {
+	return prd.commits
 }
 
 func (prd *ProviderResourceData) GetGitClient(ctx context.Context) (*gogit.Client, error) {


### PR DESCRIPTION
This PR removes the following attributes from the repository_file resource: `author_name,` `author_email` and `message`. Instead, the following attribute has been added on the provider:

```
commits = {
  author_name  = ""
  author_email = ""
  message      = ""
}
```

The `author_name` attribute defaults to "Terraform Provider Git" and the commit `message` defaults to "Write file with Terraform Provider Git"..