### PR TITLE
Add dynamic branch generation to provider configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,9 @@ description: |-
 
 ### Optional
 
-- `branch` (String) Branchname to use for commits.
+- `branch` (String) Branchname to use for commits. Conflicts with `dynamic_branch`. If neither is set, `main` is used.
 - `commits` (Attributes) (see [below for nested schema](#nestedatt--commits))
+- `dynamic_branch` (Attributes) Generate a unique branch name on every run and base it on an existing branch. Conflicts with `branch`. (see [below for nested schema](#nestedatt--dynamic_branch))
 - `http` (Attributes) (see [below for nested schema](#nestedatt--http))
 - `ignore_updates` (Boolean) If true, any updates to resources of type git_repository_file will be ignored.
 - `ssh` (Attributes) (see [below for nested schema](#nestedatt--ssh))
@@ -35,6 +36,17 @@ Optional:
 - `author_email` (String) Author email for commits.
 - `author_name` (String) Author name for commits.
 - `message` (String) Commit message.
+
+
+<a id="nestedatt--dynamic_branch"></a>
+### Nested Schema for `dynamic_branch`
+
+Optional:
+
+- `base` (String) Branch the new branch is created from. Defaults to `main`.
+- `prefix` (String) String prepended to the generated timestamp, e.g. `terraform/`.
+- `suffix` (String) String appended to the generated timestamp.
+- `timestamp_format` (String) Go reference time layout used for the timestamp portion of the branch name. Defaults to `2006-01-02-15-04` (Year-Month-Day-Hour-Minute).
 
 
 <a id="nestedatt--http"></a>

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -10,6 +12,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
+
+type DynamicBranch struct {
+	Prefix          types.String `tfsdk:"prefix"`
+	Suffix          types.String `tfsdk:"suffix"`
+	Base            types.String `tfsdk:"base"`
+	TimestampFormat types.String `tfsdk:"timestamp_format"`
+}
+
+type GitProviderModel struct {
+	Url           types.String   `tfsdk:"url"`
+	Branch        types.String   `tfsdk:"branch"`
+	DynamicBranch *DynamicBranch `tfsdk:"dynamic_branch"`
+	Ssh           *Ssh           `tfsdk:"ssh"`
+	Http          *Http          `tfsdk:"http"`
+	Commits       *Commits       `tfsdk:"commits"`
+	IgnoreUpdates types.Bool     `tfsdk:"ignore_updates"`
+}
 
 type Ssh struct {
 	Username   types.String `tfsdk:"username"`
@@ -28,15 +47,6 @@ type Commits struct {
 	AuthorName  types.String `tfsdk:"author_name"`
 	AuthorEmail types.String `tfsdk:"author_email"`
 	Message     types.String `tfsdk:"message"`
-}
-
-type GitProviderModel struct {
-	Url           types.String `tfsdk:"url"`
-	Branch        types.String `tfsdk:"branch"`
-	Ssh           *Ssh         `tfsdk:"ssh"`
-	Http          *Http        `tfsdk:"http"`
-	Commits       *Commits     `tfsdk:"commits"`
-	IgnoreUpdates types.Bool   `tfsdk:"ignore_updates"`
 }
 
 func (c *Commits) Author() string {
@@ -86,8 +96,30 @@ func (p *GitProvider) Schema(ctx context.Context, req provider.SchemaRequest, re
 				Required: true,
 			},
 			"branch": schema.StringAttribute{
-				Description: "Branchname to use for commits.",
+				Description: "Branchname to use for commits. Conflicts with `dynamic_branch`. If neither is set, `main` is used.",
 				Optional:    true,
+			},
+			"dynamic_branch": schema.SingleNestedAttribute{
+				Description: "Generate a unique branch name on every run and base it on an existing branch. Conflicts with `branch`.",
+				Attributes: map[string]schema.Attribute{
+					"prefix": schema.StringAttribute{
+						Description: "String prepended to the generated timestamp, e.g. `terraform/`.",
+						Optional:    true,
+					},
+					"suffix": schema.StringAttribute{
+						Description: "String appended to the generated timestamp.",
+						Optional:    true,
+					},
+					"base": schema.StringAttribute{
+						Description: "Branch the new branch is created from. Defaults to `main`.",
+						Optional:    true,
+					},
+					"timestamp_format": schema.StringAttribute{
+						Description: "Go reference time layout used for the timestamp portion of the branch name. Defaults to `2006-01-02-15-04` (Year-Month-Day-Hour-Minute).",
+						Optional:    true,
+					},
+				},
+				Optional: true,
 			},
 			"ssh": schema.SingleNestedAttribute{
 				Attributes: map[string]schema.Attribute{
@@ -161,14 +193,67 @@ func (p *GitProvider) Configure(ctx context.Context, req provider.ConfigureReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	branch, baseBranch, dynamic, err := resolveBranch(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid Branch Configuration", err.Error())
+		return
+	}
+
 	resp.ResourceData = &ProviderResourceData{
 		url:            data.Url.ValueString(),
-		branch:         data.Branch.ValueString(),
+		branch:         branch,
+		baseBranch:     baseBranch,
+		dynamicBranch:  dynamic,
 		ssh:            data.Ssh,
 		http:           data.Http,
 		commits:        newCommits(&data),
 		ignore_updates: data.IgnoreUpdates.ValueBool(),
 	}
+}
+
+// defaultBaseBranch is used as the branch new dynamic branches are based on, as
+// well as the branch checked out when no branch is configured at all.
+const defaultBaseBranch = "main"
+
+// defaultTimestampFormat is the Go reference time layout used for the timestamp
+// portion of a dynamic branch name (Year-Month-Day-Hour-Minute).
+const defaultTimestampFormat = "2006-01-02-15-04"
+
+// resolveBranch determines the branch to commit to. It returns the resolved
+// branch name, the branch it should be based on, and whether the branch is
+// dynamically generated and therefore may need to be created.
+func resolveBranch(m *GitProviderModel) (branch string, base string, dynamic bool, err error) {
+	hasStatic := m.Branch.ValueString() != ""
+	hasDynamic := m.DynamicBranch != nil
+
+	if hasStatic && hasDynamic {
+		return "", "", false, fmt.Errorf("only one of \"branch\" or \"dynamic_branch\" may be set")
+	}
+
+	if hasDynamic {
+		db := m.DynamicBranch
+
+		base := db.Base.ValueString()
+		if base == "" {
+			base = defaultBaseBranch
+		}
+
+		format := db.TimestampFormat.ValueString()
+		if format == "" {
+			format = defaultTimestampFormat
+		}
+
+		timestamp := time.Now().UTC().Format(format)
+		name := db.Prefix.ValueString() + timestamp + db.Suffix.ValueString()
+		return name, base, true, nil
+	}
+
+	if hasStatic {
+		return m.Branch.ValueString(), m.Branch.ValueString(), false, nil
+	}
+
+	return defaultBaseBranch, defaultBaseBranch, false, nil
 }
 
 func (p *GitProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/provider_resource_data.go
+++ b/internal/provider/provider_resource_data.go
@@ -15,6 +15,8 @@ import (
 type ProviderResourceData struct {
 	url            string
 	branch         string
+	baseBranch     string
+	dynamicBranch  bool
 	ssh            *Ssh
 	http           *Http
 	commits        *Commits
@@ -46,6 +48,13 @@ func (prd *ProviderResourceData) GetGitClient(ctx context.Context) (*gogit.Clien
 	if prd.http != nil && prd.http.InsecureHttpAllowed.ValueBool() {
 		clientOpts = append(clientOpts, gogit.WithInsecureCredentialsOverHTTP())
 	}
+	// When the branch is generated dynamically it may not exist yet. Fetch all
+	// remote branches so SwitchBranch can either track the existing dynamic
+	// branch (e.g. created earlier in the same run) or create it from the base
+	// branch.
+	if prd.dynamicBranch {
+		clientOpts = append(clientOpts, gogit.WithSingleBranch(false))
+	}
 	tmpDir, err := os.MkdirTemp("", "terraform-provider-git")
 	if err != nil {
 		return nil, err
@@ -54,6 +63,25 @@ func (prd *ProviderResourceData) GetGitClient(ctx context.Context) (*gogit.Clien
 	if err != nil {
 		return nil, fmt.Errorf("could not create git client: %w", err)
 	}
+
+	if prd.dynamicBranch {
+		base := prd.baseBranch
+		if base == "" {
+			base = "main"
+		}
+		_, err = client.Clone(ctx, prd.url, repository.CloneConfig{CheckoutStrategy: repository.CheckoutStrategy{Branch: base}})
+		if err != nil {
+			return nil, err
+		}
+		// Create the dynamic branch from the base branch, or check out the
+		// existing dynamic branch if it was already created remotely.
+		err = client.SwitchBranch(ctx, prd.branch)
+		if err != nil {
+			return nil, fmt.Errorf("could not switch to branch %q based on %q: %w", prd.branch, base, err)
+		}
+		return client, nil
+	}
+
 	branch := prd.branch
 	if branch == "" {
 		branch = "main"


### PR DESCRIPTION
Add a dynamic_branch block to the provider config that generates a unique branch name on every run (prefix + timestamp + suffix) based on an existing branch. Mutually exclusive with the static branch attribute. Dynamic branches are created from the base branch via SwitchBranch with all remote refs fetched.