### PR TITLE
fix: add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env variable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ name: release
 on:
   release:
     types: [published]
+  env: 
+    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,8 +13,8 @@ name: release
 on:
   release:
     types: [published]
-  env: 
-    FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
set environment variable for Node.js version in release workflow to force (controlled) updated version to evaluate if breaks happens or not